### PR TITLE
feat: add horizontal sliders

### DIFF
--- a/src/components/HowItWorksSection.tsx
+++ b/src/components/HowItWorksSection.tsx
@@ -52,9 +52,12 @@ const HowItWorksSection = () => {
                                 <h2 className='text-3xl md:text-4xl font-bold mb-8 text-center'>
                                         Как работает сервис
                                 </h2>
-                                <div className='space-y-8 max-w-4xl mx-auto'>
+                                <div className='flex gap-6 overflow-x-auto snap-x snap-mandatory pb-4'>
                                         {features.map(({ title, description }, idx) => (
-                                                <div key={idx}>
+                                                <div
+                                                        key={idx}
+                                                        className='shrink-0 w-72 bg-white p-4 rounded-lg shadow snap-start'
+                                                >
                                                         <h3 className='text-xl font-semibold mb-2'>{title}</h3>
                                                         <p className='text-gray-700'>{description}</p>
                                                 </div>

--- a/src/components/ScenariosSection.tsx
+++ b/src/components/ScenariosSection.tsx
@@ -31,9 +31,12 @@ const ScenariosSection = () => {
                 <section className='py-16 bg-white'>
                         <div className='container mx-auto px-4 text-center'>
                                 <h2 className='text-3xl md:text-4xl font-bold mb-8'>Готовые сценарии</h2>
-                                <div className='space-y-6 text-left max-w-3xl mx-auto mb-8'>
+                                <div className='flex gap-6 overflow-x-auto snap-x snap-mandatory mb-8 pb-4'>
                                         {scenarios.map(({ title, description }, idx) => (
-                                                <div key={idx}>
+                                                <div
+                                                        key={idx}
+                                                        className='shrink-0 w-72 bg-gray-50 p-4 rounded-lg shadow text-left snap-start'
+                                                >
                                                         <h3 className='text-xl font-semibold mb-2'>{title}</h3>
                                                         <p className='text-gray-700'>{description}</p>
                                                 </div>


### PR DESCRIPTION
## Summary
- add horizontally scrollable slider layout to the service workflow section
- add horizontal slider for preset scenarios

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a2d62c6a80832785c4a3429266119a